### PR TITLE
docs: updated package.json homepage url

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ const got = require('got')
 
 const cache = new Keyv({ store: new KeyvRedis('redis://user:pass@localhost:6379') })
 
-await got('https://keyv.js.org', { cache })
+await got('https://keyvhq.js.org', { cache })
 ```
 
 The recommended pattern is to expose a `cache` option in your modules options which is passed through to **Keyv**.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/monorepo",
   "description": "Simple key-value storage with support for multiple backends",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "",
   "author": {
     "email": "hello@microlink.io",

--- a/packages/compress/README.md
+++ b/packages/compress/README.md
@@ -10,7 +10,7 @@ $ npm install @keyvhq/compress --save
 
 ## Usage
 
-All you need to do is to wrap your [keyv](https://keyv.js.org) instance:
+All you need to do is to wrap your [keyv](https://keyvhq.js.org) instance:
 
 ```js
 const KeyvRedis = require('@keyvhq/redis')

--- a/packages/compress/package.json
+++ b/packages/compress/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/compress",
   "description": "Adds compression bindings for your Keyv instance, saving as much space as you can.",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "main": "src/index.js",
   "author": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/core",
   "description": "Simple key-value storage with support for multiple backends",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "types": "./src/index.d.ts",
   "main": "src/index.js",

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/file",
   "description": "A file storage adapter for Keyv",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "types": "src/index.d.ts",
   "main": "src/index.js",

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/memoize",
   "description": "Memoize any function using Keyv as storage backend.",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.9",
   "types": "./src/index.d.ts",
   "main": "src/index.js",

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/mongo",
   "description": "MongoDB storage adapter for Keyv",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "types": "./src/index.d.ts",
   "main": "src/index.js",

--- a/packages/multi/README.md
+++ b/packages/multi/README.md
@@ -10,7 +10,7 @@ npm install --save @keyvhq/multi
 
 ## Usage
 
-First, you need to provide your `local` and `remote` stores to be used, being possible to use any [Keyv storage adapter](https://keyv.js.org/#/?id=storage-adapters-1#/?id=storage-adapters-1#/?id=storage-adapters-1):
+First, you need to provide your `local` and `remote` stores to be used, being possible to use any [Keyv storage adapter](https://keyvhq.js.org/#/?id=storage-adapters-1#/?id=storage-adapters-1#/?id=storage-adapters-1):
 
 ```js
 const KeyvMulti = require('@keyvhq/multi')
@@ -25,7 +25,7 @@ const keyv = new Keyv({
 })
 ```
 
-After that, just interact with the store as a single [keyv](https://keyv.js.org/#/?id=usage#/?id=usage#/?id=usage) instance.
+After that, just interact with the store as a single [keyv](https://keyvhq.js.org/#/?id=usage#/?id=usage#/?id=usage) instance.
 
 The actions will be performed in parallel when is possible, and the stores will fallback between them to keep them in synchronized.
 

--- a/packages/multi/package.json
+++ b/packages/multi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/multi",
   "description": "Layered cache with any backend",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "types": "./src/index.d.ts",
   "main": "src/index.js",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/mysql",
   "description": "MySQL/MariaDB storage adapter for Keyv",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "types": "./src/index.d.ts",
   "main": "src/index.js",

--- a/packages/offline/README.md
+++ b/packages/offline/README.md
@@ -10,7 +10,7 @@ $ npm install @keyvhq/offline --save
 
 ## Usage
 
-All you need to do is to wrap your [keyv](https://keyv.js.org) instance:
+All you need to do is to wrap your [keyv](https://keyvhq.js.org) instance:
 
 ```js
 const KeyvRedis = require('@keyvhq/redis')

--- a/packages/offline/package.json
+++ b/packages/offline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/offline",
   "description": "Adding offline capabilities for your keyv instance.",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.10",
   "main": "src/index.js",
   "author": {

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/postgres",
   "description": "PostgreSQL storage adapter for Keyv",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "types": "./src/index.d.ts",
   "main": "src/index.js",

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/sql",
   "description": "Parent class for SQL based Keyv storage adapters",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "main": "src/index.js",
   "author": {

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/sqlite",
   "description": "SQLite storage adapter for Keyv",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "types": "./src/index.d.ts",
   "main": "src/index.js",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/stats",
   "description": "Collects metrics for a Keyv instance over time.",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "types": "./src/index.d.ts",
   "main": "src/index.js",

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keyvhq/test-suite",
   "description": "Test suite for Keyv API compliancy",
-  "homepage": "https://keyv.js.org",
+  "homepage": "https://keyvhq.js.org",
   "version": "2.1.7",
   "main": "src/index.js",
   "author": {


### PR DESCRIPTION
We recently changed domains. See #203 
Now npmjs links this project to a 404 since it they use the root package.json homepage property to display the project's homepage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation examples and README links to use https://keyvhq.js.org so published docs reference the correct site.

* **Chores**
  * Updated package metadata/homepage entries across packages to https://keyvhq.js.org.
  * No changes to functionality, scripts, dependencies, exported APIs, or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->